### PR TITLE
Fix mutable default for player input state

### DIFF
--- a/server/main.py
+++ b/server/main.py
@@ -28,7 +28,7 @@ import os
 import random
 import string
 import time
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass, field, asdict
 from typing import Dict, Set, Tuple, Optional, List
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect
@@ -79,7 +79,7 @@ class Player:
     speed: float = DEFAULT_PLAYER_SPEED
     label: str = "P"
     color: str = "#2563eb"
-    input: InputState = InputState()
+    input: InputState = field(default_factory=InputState)
 
     def integrate(self, dt: float) -> None:
         """Integrate movement using current input.


### PR DESCRIPTION
## Summary
- avoid shared Player.input state by using dataclass `field(default_factory=InputState)`

## Testing
- `timeout 2s uvicorn server.main:app --port 8000`

------
https://chatgpt.com/codex/tasks/task_e_68a252e4e1188325aa210a6cc87de353